### PR TITLE
Clean cancellation of running flowdump

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,15 +1,21 @@
+// +build go1.7
+
 package main
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	flag "github.com/ogier/pflag"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/pcap"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -27,64 +33,111 @@ func usage() {
 }
 
 func main() {
-	os.Exit(flowDump())
+	var (
+		errC   chan error
+		sigC   = make(chan os.Signal, 1)
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	signal.Notify(sigC,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+	)
+
+	errC = flowDump(ctx)
+
+	for {
+		select {
+		case <-sigC:
+			cancel()
+		case err := <-errC:
+			if err != nil {
+				if err == context.Canceled {
+					fmt.Fprintln(os.Stderr, "Terminated by user")
+				} else {
+					fmt.Fprintln(os.Stderr, err.Error())
+					os.Exit(1)
+				}
+			}
+			os.Exit(0)
+		}
+	}
 }
 
-func flowDump() int {
-	flag.Usage = usage
-	flag.StringVarP(&iface, "interface", "i", defaultIface(), "Interface to listen on")
-	flag.IntVarP(&snaplen, "snaplen", "s", 1600, "Maximum number of bytes to read from each packet")
-	flag.StringVarP(&pcapFile, "file", "r", "", "Read from a pcap file instead of listening")
-	flag.BoolVarP(&force, "force", "f", false, "Run even if no filter is provided")
-	flag.Parse()
+func flowDump(ctx context.Context) chan error {
+	errC := make(chan error)
 
-	var handle *pcap.Handle
-	var err error
-	if pcapFile != "" {
-		// Read from file
-		handle, err = pcap.OpenOffline(pcapFile)
+	go func() {
+		defer close(errC)
 
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Couldn't open %s: %s\n", pcapFile, err)
-			return 1
-		}
-	} else {
-		// Live packet capture
-		handle, err = pcap.OpenLive(iface, int32(snaplen), true, pcap.BlockForever)
+		flag.Usage = usage
+		flag.StringVarP(&iface, "interface", "i", defaultIface(), "Interface to listen on")
+		flag.IntVarP(&snaplen, "snaplen", "s", 1600, "Maximum number of bytes to read from each packet")
+		flag.StringVarP(&pcapFile, "file", "r", "", "Read from a pcap file instead of listening")
+		flag.BoolVarP(&force, "force", "f", false, "Run even if no filter is provided")
+		flag.Parse()
 
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Couldn't listen on %s: %s\n", iface, err)
-			return 1
+		var handle *pcap.Handle
+		var err error
+		if pcapFile != "" {
+			// Read from file
+			handle, err = pcap.OpenOffline(pcapFile)
+
+			if err != nil {
+				errC <- errors.Wrapf(err, "couldn't open %s", pcapFile)
+				return
+			}
 		} else {
+			// Live packet capture
+			handle, err = pcap.OpenLive(iface, int32(snaplen), true, pcap.BlockForever)
+
+			if err != nil {
+				errC <- errors.Wrapf(err, "couldn't listen on %s", iface)
+				return
+			}
 			fmt.Fprintf(os.Stderr, "Listening on %s (snaplen %d bytes)\n", iface, snaplen)
 		}
-	}
-	defer handle.Close()
+		defer handle.Close()
 
-	// Set packet filter if provided
-	filterParts := flag.Args()
-	if len(filterParts) > 0 {
-		if err = handle.SetBPFFilter(strings.Join(filterParts, " ")); err != nil {
-			panic(err)
+		// Set packet filter if provided
+		filterParts := flag.Args()
+		if len(filterParts) > 0 {
+			if err = handle.SetBPFFilter(strings.Join(filterParts, " ")); err != nil {
+				errC <- errors.Wrap(err, "filter compilation failure")
+			}
+		} else {
+			fmt.Fprintln(os.Stderr, "No packet filter provided - this probably isn't what you want!")
+			if !force {
+				fmt.Fprintln(os.Stderr, "Exiting; use --force if you really want to do this.")
+				return
+			}
 		}
-	} else {
-		fmt.Fprintln(os.Stderr, "No packet filter provided - this probably isn't what you want!")
-		if !force {
-			fmt.Fprintln(os.Stderr, "Exiting; use --force if you really want to do this.")
-			return 1
-		}
-	}
 
-	// Now dump all of the packets
-	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
-	for packet := range packetSource.Packets() {
-		tl := packet.TransportLayer()
-		if tl != nil {
-			os.Stdout.Write(tl.LayerPayload())
-		}
-	}
+		// Now dump all of the packets
+		packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
+		packetC := packetSource.Packets()
 
-	return 0
+		for {
+			select {
+			case <-ctx.Done():
+				errC <- ctx.Err()
+				return
+			case packet, ok := <-packetC:
+				if !ok {
+					return
+				}
+				tl := packet.TransportLayer()
+				if tl != nil {
+					_, _ = os.Stdout.Write(tl.LayerPayload())
+				}
+			}
+		}
+
+	}()
+	return errC
 }
 
 // Find the first non-loopback interface that's up

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 	signal.Notify(sigC,
 		syscall.SIGINT,
 		syscall.SIGTERM,
+		syscall.SIGPIPE,
 	)
 
 	errC = flowDump(ctx)


### PR DESCRIPTION
Makes use of new context package in go 1.7, and could be used to ensure
data are flushed to one or more outputs in the future.  Does require the
1.7 compiler, however.
